### PR TITLE
Rewrite assertions for non-empty returns

### DIFF
--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -72,21 +72,24 @@ class ImageTest extends PHPUnit_Framework_TestCase
 
     /**
      * @depends testPublicToStringMethodExists
-     * @testdox Public __toString() method returns non-empty string
+     * @testdox Image::__toString() returns non-empty string
      */
-    public function testPublicToStringMethodReturnsNonEmptyString()
+    public function testImageToStringReturnsNonEmptyString()
     {
         $image = new \StoreCore\Image();
-        $this->assertFalse(empty($image->__toString()));
-        $this->assertFalse(empty((string)$image));
-        $this->assertTrue(is_string($image->__toString()));
+
+        $this->assertNotEmpty($image->__toString());
+        $this->assertInternalType('string', $image->__toString());
+
+        $this->assertNotEmpty((string)$image);
+        $this->assertInternalType('string', (string)$image);
     }
 
     /**
-     * @depends testPublicToStringMethodReturnsNonEmptyString
-     * @testdox Public __toString() method returns <img> tag
+     * @depends testImageToStringReturnsNonEmptyString
+     * @testdox Image::__toString() returns <img> tag
      */
-    public function testPublicToStringMethodReturnsImgTag()
+    public function testImageToStringReturnsImgTag()
     {
         $image = new \StoreCore\Image();
         $this->assertStringStartsWith('<img ', (string)$image);
@@ -359,7 +362,7 @@ class ImageTest extends PHPUnit_Framework_TestCase
         $this->assertSame(7680, $image->getWidth());
         $this->assertSame(4320, $image->getHeight());
     }
-    
+
     /**
      * @expectedException \DomainException
      * @testdox Public setWidth() method throws \DomainException on width over 7680

--- a/tests/Types/InternationalArticleNumberTest.php
+++ b/tests/Types/InternationalArticleNumberTest.php
@@ -134,13 +134,13 @@ class InternationalArticleNumberTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @testdox Public __toString() method returns non-empty string
+     * @testdox InternationalArticleNumber::__toString() returns non-empty string
      */
-    public function testPublicToStringMethodReturnsNonEmptyString()
+    public function testInternationalArticleNumberToStringReturnsNonEmptyString()
     {
         $ean = new \StoreCore\Types\InternationalArticleNumber('0190198067098');
         $ean = (string)$ean;
-        $this->assertFalse(empty($ean));
+        $this->assertNotEmpty($ean);
     }
 
     /**

--- a/tests/Types/ProductThingTest.php
+++ b/tests/Types/ProductThingTest.php
@@ -99,12 +99,13 @@ class ProductThingTest extends PHPUnit_Framework_TestCase
 
     /**
      * @group hmvc
-     * @testdox Public __toString() method returns non-empty string
+     * @testdox Product::__toString() returns non-empty string
      */
-    public function testPublicToStringMethodReturnsNonEmptyString()
+    public function testProductToStringReturnsNonEmptyString()
     {
         $product = new \StoreCore\Types\Product();
         $product = (string)$product;
-        $this->assertFalse(empty($product));
+        $this->assertNotEmpty($product);
+        $this->assertInternalType('string', $product);
     }
 }

--- a/tests/Types/ThingTest.php
+++ b/tests/Types/ThingTest.php
@@ -99,12 +99,13 @@ class ThingTest extends PHPUnit_Framework_TestCase
 
     /**
      * @group hmvc
-     * @testdox Public __toString() method returns non-empty string
+     * @testdox Thing::__toString() returns non-empty string
      */
-    public function testPublicToStringMethodReturnsNonEmptyString()
+    public function testThingToStringReturnsNonEmptyString()
     {
         $thing = new \StoreCore\Types\Thing();
         $thing = (string)$thing;
-        $this->assertFalse(empty($thing));
+        $this->assertNotEmpty($thing);
+        $this->assertInternalType('string', $thing);
     }
 }


### PR DESCRIPTION
Rewrites `assertFalse(empty(…))` to `assertNotEmpty(…)`.